### PR TITLE
Fix qs params without values

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,15 @@ var qs = require('querystringify');
 
 ### qs.parse()
 
-The parse method transforms a given query string in to an object. It does not
-care if your query string if prefixed with a `?` or not. It just extracts the
-parts between the `=` and `&`:
+The parse method transforms a given query string in to an object. Parameters
+without values are set to `null`. It does not care if your query string is
+prefixed with a `?` or not. It just extracts the parts between the `=` and `&`:
 
 ```js
 qs.parse('?foo=bar');         // { foo: 'bar' }
 qs.parse('foo=bar');          // { foo: 'bar' }
 qs.parse('foo=bar&bar=foo');  // { foo: 'bar', bar: 'foo' }
+qs.parse('foo&bar=foo');      // { foo: null, bar: 'foo' }
 ```
 
 ### qs.stringify()

--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@ var qs = require('querystringify');
 ### qs.parse()
 
 The parse method transforms a given query string in to an object. Parameters
-without values are set to `null`. It does not care if your query string is
-prefixed with a `?` or not. It just extracts the parts between the `=` and `&`:
+without values are set to empty strings. It does not care if your query string
+is prefixed with a `?` or not. It just extracts the parts between the `=` and
+`&`:
 
 ```js
 qs.parse('?foo=bar');         // { foo: 'bar' }
 qs.parse('foo=bar');          // { foo: 'bar' }
 qs.parse('foo=bar&bar=foo');  // { foo: 'bar', bar: 'foo' }
-qs.parse('foo&bar=foo');      // { foo: null, bar: 'foo' }
+qs.parse('foo&bar=foo');      // { foo: '', bar: 'foo' }
 ```
 
 ### qs.stringify()
@@ -51,7 +52,7 @@ simply supply a string with the prefix value as second argument:
 qs.stringify({ foo: bar });       // foo=bar
 qs.stringify({ foo: bar }, true); // ?foo=bar
 qs.stringify({ foo: bar }, '&');  // &foo=bar
-qs.stringify({ foo: null }, '&'); // &foo
+qs.stringify({ foo: '' }, '&');   // &foo=
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ simply supply a string with the prefix value as second argument:
 qs.stringify({ foo: bar });       // foo=bar
 qs.stringify({ foo: bar }, true); // ?foo=bar
 qs.stringify({ foo: bar }, '&');  // &foo=bar
+qs.stringify({ foo: null }, '&'); // &foo
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -38,8 +38,7 @@ function querystring(query) {
 function querystringify(obj, prefix) {
   prefix = prefix || '';
 
-  var pairs = []
-    , value;
+  var pairs = [];
 
   //
   // Optionally prefix with a '?' if needed
@@ -48,7 +47,7 @@ function querystringify(obj, prefix) {
 
   for (var key in obj) {
     if (has.call(obj, key)) {
-      pairs.push(encodeURIComponent(key) +'='+ encodeURIComponent(obj[key]))
+      pairs.push(encodeURIComponent(key) +'='+ encodeURIComponent(obj[key]));
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var has = Object.prototype.hasOwnProperty;
  * @api public
  */
 function querystring(query) {
-  var parser = /([^=?&]+)=([^&]*)/g
+  var parser = /([^=?&]+)=?([^&]*)?/g
     , result = {}
     , part;
 
@@ -21,7 +21,7 @@ function querystring(query) {
   //
   for (;
     part = parser.exec(query);
-    result[decodeURIComponent(part[1])] = decodeURIComponent(part[2])
+    result[decodeURIComponent(part[1])] = part[2] ? decodeURIComponent(part[2]) : null
   );
 
   return result;

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var has = Object.prototype.hasOwnProperty;
  * @api public
  */
 function querystring(query) {
-  var parser = /([^=?&]+)=?([^&]*)?/g
+  var parser = /([^=?&]+)=?([^&]*)/g
     , result = {}
     , part;
 
@@ -21,7 +21,7 @@ function querystring(query) {
   //
   for (;
     part = parser.exec(query);
-    result[decodeURIComponent(part[1])] = part[2] ? decodeURIComponent(part[2]) : null
+    result[decodeURIComponent(part[1])] = decodeURIComponent(part[2])
   );
 
   return result;
@@ -48,8 +48,7 @@ function querystringify(obj, prefix) {
 
   for (var key in obj) {
     if (has.call(obj, key)) {
-      value = obj[key] ? '=' + encodeURIComponent(obj[key]) : ''
-      pairs.push(encodeURIComponent(key) + value);
+      pairs.push(encodeURIComponent(key) +'='+ encodeURIComponent(obj[key]))
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ function querystring(query) {
 function querystringify(obj, prefix) {
   prefix = prefix || '';
 
-  var pairs = [];
+  var pairs = []
+    , value;
 
   //
   // Optionally prefix with a '?' if needed
@@ -47,7 +48,8 @@ function querystringify(obj, prefix) {
 
   for (var key in obj) {
     if (has.call(obj, key)) {
-      pairs.push(encodeURIComponent(key) +'='+ encodeURIComponent(obj[key]));
+      value = obj[key] ? '=' + encodeURIComponent(obj[key]) : ''
+      pairs.push(encodeURIComponent(key) + value);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/unshiftio/querystringify",
   "devDependencies": {
-    "assume": "1.3.x",
+    "assume": "1.4.x",
     "istanbul": "0.4.x",
     "mocha": "2.4.x",
     "pre-commit": "1.1.x"

--- a/test.js
+++ b/test.js
@@ -32,7 +32,7 @@ describe('querystringify', function () {
     });
 
     it('works with object keys with null values', function () {
-      assume(qs.stringify({ foo: null })).equals('foo')
+      assume(qs.stringify({ foo: '' })).equals('foo=')
     })
 
     it('works with nulled objects', function () {
@@ -64,11 +64,12 @@ describe('querystringify', function () {
     });
 
     it('works with querystring parameters without values', function () {
-      var obj = qs.parse('?foo&bar=baz');
+      var obj = qs.parse('?foo&bar=&shizzle=mynizzle');
 
       assume(obj).is.a('object');
-      assume(obj.foo).equals(null);
-      assume(obj.bar).equals('baz');
+      assume(obj.foo).equals('');
+      assume(obj.bar).equals('');
+      assume(obj.shizzle).equals('mynizzle');
     })
   });
 });

--- a/test.js
+++ b/test.js
@@ -31,8 +31,8 @@ describe('querystringify', function () {
       assume(qs.stringify({})).equals('');
     });
 
-    it('works with object keys with null values', function () {
-      assume(qs.stringify({ foo: '' })).equals('foo=')
+    it('works with object keys with empty string values', function () {
+      assume(qs.stringify({ foo: '' })).equals('foo=');
     })
 
     it('works with nulled objects', function () {

--- a/test.js
+++ b/test.js
@@ -58,5 +58,13 @@ describe('querystringify', function () {
       assume(obj.foo).equals('bar');
       assume(obj.shizzle).equals('mynizzle');
     });
+
+    it('works with querystring parameters without values', function () {
+      var obj = qs.parse('?foo&bar=baz');
+
+      assume(obj).is.a('object');
+      assume(obj.foo).equals(null);
+      assume(obj.bar).equals('baz');
+    })
   });
 });

--- a/test.js
+++ b/test.js
@@ -31,6 +31,10 @@ describe('querystringify', function () {
       assume(qs.stringify({})).equals('');
     });
 
+    it('works with object keys with null values', function () {
+      assume(qs.stringify({ foo: null })).equals('foo')
+    })
+
     it('works with nulled objects', function () {
       var obj = Object.create(null);
 


### PR DESCRIPTION
This adds support to Querystringify for parsing querystring parameters which don't have values, such as `?foo`, & for the reverse scenario: stringifying objects with null value keys.

I've updated the Readme to give examples of both of the above.  

Also included is an update to the `assume` devDependency, as the listed version triggered the npm error described [here](https://github.com/bigpipe/assume/issues/17).

Resolves https://github.com/unshiftio/querystringify/issues/1