### PR TITLE
[security] Prevent overriding of build-in properties by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: node_js
 node_js:
   - "4"
-  - "5"
   - "6"
   - "8"
   - "9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 sudo: false
 language: node_js
 node_js:
-  - "5"
   - "4"
-  - "0.12"
-  - "0.10"
-  - "0.8"
-before_install:
-  - 'if [ "${TRAVIS_NODE_VERSION}" == "0.8" ]; then npm install -g npm@2.14.15; fi'
+  - "5"
+  - "6"
+  - "8"
+  - "9"
 script:
   - "npm run test-travis"
 after_script:

--- a/index.js
+++ b/index.js
@@ -25,15 +25,18 @@ function querystring(query) {
     , result = {}
     , part;
 
-  //
-  // Little nifty parsing hack, leverage the fact that RegExp.exec increments
-  // the lastIndex property so we can continue executing this loop until we've
-  // parsed all results.
-  //
-  for (;
-    part = parser.exec(query);
-    result[decode(part[1])] = decode(part[2])
-  );
+  while (part = parser.exec(query)) {
+    var key = decode(part[1])
+      , value = decode(part[2]);
+
+    //
+    // Prevent overriding of existing properties. This ensures that build-in
+    // methods like `toString` or __proto__ are not overriden by malicious
+    // querystrings.
+    //
+    if (key in result) continue;
+    result[key] = value;
+  }
 
   return result;
 }

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   },
   "homepage": "https://github.com/unshiftio/querystringify",
   "devDependencies": {
-    "assume": "~1.5.0",
-    "istanbul": "0.4.x",
-    "mocha": "~3.5.0",
-    "pre-commit": "~1.2.0"
+    "assume": "^2.0.1",
+    "istanbul": "^0.4.5",
+    "mocha": "^5.1.1",
+    "pre-commit": "^1.2.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -63,6 +63,14 @@ describe('querystringify', function () {
       assume(obj.shizzle).equals('mynizzle');
     });
 
+    it('does not overide prototypes', function () {
+      var obj = qs.parse('?toString&__proto__=lol');
+
+      assume(obj).is.a('object');
+      assume(obj.toString).is.a('function');
+      assume(obj.__proto__).does.not.equals('lol');
+    });
+
     it('works with querystring parameters without values', function () {
       var obj = qs.parse('?foo&bar=&shizzle=mynizzle');
 


### PR DESCRIPTION
Currently, it's possible to override built-in properties of the resulting query string object if a malicious string is inserted in the query string, for example `?toString&` will set the `toString` method of the object to the `true` boolean. This patch ensures that we never override built-in properties or previously set properties. 