### PR TITLE
[fix] Empty string for undefined and null

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,11 +61,19 @@ function querystringify(obj, prefix) {
 
   for (var key in obj) {
     if (has.call(obj, key)) {
-      pairs.push(encodeURIComponent(key) +'='+ encodeURIComponent(obj[key]));
+      pairs.push(encode(key) +'='+ encode(obj[key]));
     }
   }
 
   return pairs.length ? prefix + pairs.join('&') : '';
+}
+
+function encode(value) {
+  if (typeof value === 'undefined' || value === null) {
+    return '';
+  }
+
+  return encodeURIComponent(value);
 }
 
 //

--- a/test.js
+++ b/test.js
@@ -35,6 +35,14 @@ describe('querystringify', function () {
       assume(qs.stringify({ foo: '' })).equals('foo=');
     });
 
+    it('should put empty string for undefined', function () {
+      assume(qs.stringify({ foo: undefined })).equals('foo=');
+    });
+
+    it('should put empty string for null', function () {
+      assume(qs.stringify({ foo: null })).equals('foo=');
+    });
+
     it('works with nulled objects', function () {
       var obj = Object.create(null);
 


### PR DESCRIPTION
When stringifiying object with `undefined` or `null` values, it returns `"undefined"` and `"null"`

#### Example:
```javascript
  stringify({ foo: null }) // ->  "foo=null"
  stringify({ foo: undefined }) // -> "foo=undefined"
```