### PR TITLE
Parse querystring prefixed by #

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ var qs = require('querystringify');
 
 The parse method transforms a given query string in to an object. Parameters
 without values are set to empty strings. It does not care if your query string
-is prefixed with a `?` or not. It just extracts the parts between the `=` and
-`&`:
+is prefixed with a `?`, a `#`, or not prefixed. It just extracts the parts
+between the `=` and `&`:
 
 ```js
 qs.parse('?foo=bar');         // { foo: 'bar' }
+qs.parse('#foo=bar');         // { foo: 'bar' }
 qs.parse('foo=bar');          // { foo: 'bar' }
 qs.parse('foo=bar&bar=foo');  // { foo: 'bar', bar: 'foo' }
 qs.parse('foo&bar=foo');      // { foo: '', bar: 'foo' }
@@ -51,7 +52,7 @@ simply supply a string with the prefix value as second argument:
 ```js
 qs.stringify({ foo: bar });       // foo=bar
 qs.stringify({ foo: bar }, true); // ?foo=bar
-qs.stringify({ foo: bar }, '&');  // &foo=bar
+qs.stringify({ foo: bar }, '#');  // #foo=bar
 qs.stringify({ foo: '' }, '&');   // &foo=
 ```
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function encode(input) {
  * @api public
  */
 function querystring(query) {
-  var parser = /([^=?&]+)=?([^&]*)/g
+  var parser = /([^=?#&]+)=?([^&]*)/g
     , result = {}
     , part;
 

--- a/test.js
+++ b/test.js
@@ -76,6 +76,14 @@ describe('querystringify', function () {
       assume(obj.shizzle).equals('mynizzle');
     });
 
+    it('will also work if querystring is prefixed with #', function () {
+      var obj = qs.parse('#foo=bar&shizzle=mynizzle');
+
+      assume(obj).is.a('object');
+      assume(obj.foo).equals('bar');
+      assume(obj.shizzle).equals('mynizzle');
+    });
+
     it('does not overide prototypes', function () {
       var obj = qs.parse('?toString&__proto__=lol');
 


### PR DESCRIPTION
### Overview

This PR allow querystrings to be prefixed by `#`, just like they can be prefixed by `?` currently.

The rationale is for using with `window.location.hash`.

### What do other libraries do?

Parsing `#foo=bar`:
 - `{ 'foo': 'bar' }`
    + [query-string](https://www.npmjs.com/package/query-string)
 - `{ '#foo': 'bar' }`
    + node itself
    + [qs](https://www.npmjs.com/package/qs)

### Final thoughts

I think there is no reason not to do it, because `#foo=bar` should not be a valid encoded query string (it would be `%23foo=bar`).

Feel free to discuss!